### PR TITLE
Fix compile/build/tests to use released 6.4 jars.

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,43 +13,57 @@ import sys
 import os
 import urllib.request
 
+# version of lucene we build against
+LUCENE_VERSION = '6.4.0'
+
 deps = [
   #('org.codehaus.jackson', 'jackson-core-asl', '1.9.13'),
   #('org.codehaus.jackson', 'jackson-mapper-asl', '1.9.13'),
   ('com.fasterxml.jackson.core', 'jackson-core', '2.8.2'),
   #('com.fasterxml.jackson.core', 'jackson-mapper', '2.8.2'),
   ('commons-codec', 'commons-codec', '1.10'),
-  ('net.minidev', 'json-smart', '1.2')
+  ('net.minidev', 'json-smart', '1.2'),
+  ('org.apache.lucene', 'lucene-core', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-analyzers-common', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-analyzers-icu', LUCENE_VERSION),
+    ('com.ibm.icu', 'icu4j', '56.1'),
+  ('org.apache.lucene', 'lucene-facet', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-codecs', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-grouping', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-highlighter', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-join', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-misc', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-queries', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-queryparser', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-suggest', LUCENE_VERSION),
+  ('org.apache.lucene', 'lucene-expressions', LUCENE_VERSION),
+    ('org.antlr', 'antlr4-runtime', '4.5.1-1'),
+    ('org.ow2.asm', 'asm', '5.1'),
+    ('org.ow2.asm', 'asm-commons', '5.1'),
+  ('org.apache.lucene', 'lucene-replicator', LUCENE_VERSION),
+    ('org.apache.httpcomponents', 'httpclient', '4.4.1'),
+    ('org.apache.httpcomponents', 'httpcore', '4.4.1'),
+    ('org.eclipse.jetty', 'jetty-server', '9.3.14.v20161028'),
+    ('javax.servlet', 'javax.servlet-api', '3.1.0'),
+    ('org.eclipse.jetty', 'jetty-servlet', '9.3.14.v20161028'),
+    ('org.eclipse.jetty', 'jetty-util', '9.3.14.v20161028'),
+    ('org.eclipse.jetty', 'jetty-io', '9.3.14.v20161028'),
+    ('org.eclipse.jetty', 'jetty-continuation', '9.3.14.v20161028'),
+    ('org.eclipse.jetty', 'jetty-http', '9.3.14.v20161028'),
+    ('commons-logging', 'commons-logging', '1.1.3'),
+  ('org.apache.lucene', 'lucene-sandbox', LUCENE_VERSION),
   ]
 
 testDeps = [
   ('de.thetaphi', 'forbiddenapis', '2.2'),
   ('com.carrotsearch.randomizedtesting', 'junit4-ant', '2.4.0'),
   ('com.carrotsearch.randomizedtesting', 'randomizedtesting-runner', '2.4.0'),
+  ('org.apache.lucene', 'lucene-test-framework', LUCENE_VERSION),
   ('junit', 'junit', '4.10')
   ]
   
-LUCENE_VERSION = '6.3.0-SNAPSHOT'
 LUCENE_SERVER_BASE_VERSION = '0.1.1'
 LUCENE_SERVER_VERSION = '%s-SNAPSHOT' % LUCENE_SERVER_BASE_VERSION
-
-luceneDeps = ('core',
-              'analyzers-common',
-              'analyzers-icu',
-              'facet',
-              'codecs',
-              'grouping',
-              'highlighter',
-              'join',
-              'misc',
-              'queries',
-              'queryparser',
-              'suggest',
-              'expressions',
-              'replicator',
-              'sandbox')
-
-luceneTestDeps = ('test-framework',)
 
 TEST_HEAP = '512m'
 
@@ -329,26 +343,6 @@ def anyChanges(srcDir, destJAR):
 
   return False
 
-def compileLuceneModules(deps):
-  os.chdir('lucene6x/lucene')
-  for dep in deps:
-    if dep.startswith('analyzers-'):
-      # lucene analyzers have two level hierarchy!
-      part = dep[10:]
-      if anyChanges('analysis/%s' % part, 'build/analysis/%s/lucene-%s-%s.jar' % (part, dep, LUCENE_VERSION)):
-        print('build lucene %s JAR...' % dep)
-        os.chdir('analysis/%s' % part)
-        # TODO: we disable compiler warnings because recent java (15+) is angry!
-        run('ant -Djavac.args= -Djavac.doclint.args= jar')
-        os.chdir('../..')
-    elif anyChanges(dep, 'build/%s/lucene-%s-%s.jar' % (dep, dep, LUCENE_VERSION)):
-      print('build lucene %s JAR...' % dep)
-      os.chdir(dep)
-      # TODO: we disable compiler warnings because recent java (15+) is angry!
-      run('ant -Djavac.args= -Djavac.doclint.args= jar')
-      os.chdir('..')
-  os.chdir(ROOT_DIR)
-
 def compileChangedSources(srcPath, destPath, classPath):
   changedSources = []
   for root, dirNames, fileNames in os.walk(srcPath):
@@ -375,15 +369,6 @@ def getCompileClassPath():
   l = []
   for org, name, version in deps:
     l.append('lib/%s-%s.jar' % (name, version))
-  for dep in luceneDeps:
-    if dep.startswith('analyzers-'):
-      l.append('lucene6x/lucene/build/analysis/%s/lucene-%s-%s.jar' % (dep[10:], dep, LUCENE_VERSION))
-      libDir = 'lucene6x/lucene/analysis/%s/lib' % dep[10:]
-    else:
-      l.append('lucene6x/lucene/build/%s/lucene-%s-%s.jar' % (dep, dep, LUCENE_VERSION))
-      libDir = 'lucene6x/lucene/%s/lib' % dep
-    if os.path.exists(libDir):
-      l.append('%s/*' % libDir)
     
   return l
 
@@ -392,11 +377,6 @@ def getTestClassPath():
   l.append('build/classes/java')
   for org, name, version in testDeps:
     l.append('lib/%s-%s.jar' % (name, version))
-  for dep in luceneTestDeps:
-    if dep.startswith('analyzers-'):
-      l.append('lucene6x/lucene/build/analysis/%s/lucene-%s-%s.jar' % (dep[10:], dep, LUCENE_VERSION))
-    else:
-      l.append('lucene6x/lucene/build/%s/lucene-%s-%s.jar' % (dep, dep, LUCENE_VERSION))
   return l
 
 def getArg(option):
@@ -430,12 +410,6 @@ def compileSourcesAndDeps(jarVersion):
     destFileName = 'lib/%s-%s.jar' % (dep[1], dep[2])
     if not os.path.exists(destFileName):
       fetchMavenJAR(*(dep + (destFileName,)))
-
-  if not os.path.exists('lucene6x'):
-    print('init: cloning lucene branch_6x to ./lucene6x...')
-    run('git clone --depth 1 -b branch_6_3 https://github.com/apache/lucene-solr.git lucene6x')
-
-  compileLuceneModules(luceneDeps)
 
   # compile luceneserver sources
   jarFileName = 'build/luceneserver-%s.jar' % jarVersion
@@ -519,16 +493,6 @@ def main():
         z.write(jarFileName, '%s/lib/luceneserver-%s.jar' % (rootDirName, jarVersion))
         for org, name, version in deps:
           z.write('lib/%s-%s.jar' % (name, version), '%s/lib/%s-%s.jar' % (rootDirName, name, version))
-        for dep in luceneDeps:
-          if dep.startswith('analyzers-'):
-            z.write('lucene6x/lucene/build/analysis/%s/lucene-%s-%s.jar' % (dep[10:], dep, LUCENE_VERSION), '%s/lib/lucene-%s-%s.jar' % (rootDirName, dep, LUCENE_VERSION))
-            libDir = 'lucene6x/lucene/analysis/%s/lib' % dep[10:]
-          else:
-            z.write('lucene6x/lucene/build/%s/lucene-%s-%s.jar' % (dep, dep, LUCENE_VERSION), '%s/lib/lucene-%s-%s.jar' % (rootDirName, dep, LUCENE_VERSION))
-            libDir = 'lucene6x/lucene/%s/lib' % dep
-          if os.path.exists(libDir):
-            for name in os.listdir(libDir):
-              z.write('%s/%s' % (libDir, name), '%s/lib/%s' % (rootDirName, name))
         z.write('scripts/indexTaxis.py', '%s/scripts/indexTaxis.py' % rootDirName)
         z.write('CHANGES.txt', '%s/CHANGES.txt' % rootDirName)
         z.write('README.md', '%s/README.md' % rootDirName)
@@ -544,8 +508,6 @@ def main():
       verbose = getFlag('-verbose')
 
       jarFileName = compileSourcesAndDeps(LUCENE_SERVER_VERSION)
-
-      compileLuceneModules(luceneTestDeps)
 
       for dep in testDeps:
         destFileName = 'lib/%s-%s.jar' % (dep[1], dep[2])
@@ -649,7 +611,7 @@ def main():
       suiteCount = 0
       while True:
         for jvm in jvms:
-          if jvm.isAlive():
+          if jvm.is_alive():
             break
         else:
           break

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@ import os
 import urllib.request
 
 # version of lucene we build against
-LUCENE_VERSION = '6.4.0'
+LUCENE_VERSION = '6.4.2'
 
 deps = [
   #('org.codehaus.jackson', 'jackson-core-asl', '1.9.13'),

--- a/src/java/org/apache/lucene/server/FieldDef.java
+++ b/src/java/org/apache/lucene/server/FieldDef.java
@@ -29,7 +29,7 @@ import java.util.TimeZone;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.util.CloseableThreadLocal;
 
@@ -80,7 +80,7 @@ public class FieldDef implements Closeable {
   public final boolean highlighted;
 
   /** Only set for a virtual field (expression). */
-  public final ValueSource valueSource;
+  public final DoubleValuesSource valueSource;
 
   /** True if this field is indexed as a dimensional point */
   public final boolean usePoints;
@@ -103,7 +103,7 @@ public class FieldDef implements Closeable {
   public FieldDef(String name, FieldType fieldType, FieldValueType valueType, String faceted,
                   String postingsFormat, String docValuesFormat, boolean multiValued, boolean usePoints,
                   Similarity sim, Analyzer indexAnalyzer, Analyzer searchAnalyzer, boolean highlighted,
-                  ValueSource valueSource, String dateTimeFormat) {
+                  DoubleValuesSource valueSource, String dateTimeFormat) {
     this.name = name;
     this.fieldType = fieldType;
     if (fieldType != null) {

--- a/src/java/org/apache/lucene/server/FieldDefBindings.java
+++ b/src/java/org/apache/lucene/server/FieldDefBindings.java
@@ -21,11 +21,7 @@ import java.util.Map;
 
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.queries.function.ValueSource;
-import org.apache.lucene.queries.function.valuesource.DoubleFieldSource;
-import org.apache.lucene.queries.function.valuesource.FloatFieldSource;
-import org.apache.lucene.queries.function.valuesource.IntFieldSource;
-import org.apache.lucene.queries.function.valuesource.LongFieldSource;
+import org.apache.lucene.search.DoubleValuesSource;
 
 /** Implements {@link Bindings} on top of the registered
  *  fields. */
@@ -39,9 +35,9 @@ public final class FieldDefBindings extends Bindings {
   }
 
   @Override
-  public ValueSource getValueSource(String name) {
+  public DoubleValuesSource getDoubleValuesSource(String name) {
     if (name.equals("_score")) {
-      return getScoreValueSource();
+      return DoubleValuesSource.SCORES;
     }
     FieldDef fd = fields.get(name);
     if (fd == null) {
@@ -51,13 +47,13 @@ public final class FieldDefBindings extends Bindings {
       return fd.valueSource;
     } else if (fd.fieldType != null && fd.fieldType.docValuesType() == DocValuesType.NUMERIC) {
       if (fd.valueType == FieldDef.FieldValueType.INT) {
-        return new IntFieldSource(name);
+        return DoubleValuesSource.fromIntField(name);
       } else if (fd.valueType == FieldDef.FieldValueType.FLOAT) {
-        return new FloatFieldSource(name);
+        return DoubleValuesSource.fromFloatField(name);
       } else if (fd.valueType == FieldDef.FieldValueType.LONG) {
-        return new LongFieldSource(name);
+        return DoubleValuesSource.fromLongField(name);
       } else if (fd.valueType == FieldDef.FieldValueType.DOUBLE) {
-        return new DoubleFieldSource(name);
+        return DoubleValuesSource.fromDoubleField(name);
       } else {
         assert false: "unknown numeric field type: " + fd.valueType;
         return null;

--- a/src/java/org/apache/lucene/server/handlers/BuildSuggestHandler.java
+++ b/src/java/org/apache/lucene/server/handlers/BuildSuggestHandler.java
@@ -32,6 +32,7 @@ import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
+import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.suggest.DocumentDictionary;
 import org.apache.lucene.search.suggest.DocumentValueSourceDictionary;
 import org.apache.lucene.search.suggest.InputIterator;
@@ -474,7 +475,8 @@ public class BuildSuggestHandler extends Handler {
         
         dict = new DocumentValueSourceDictionary(searcher.searcher.getIndexReader(),
                                                  suggestField,
-                                                 expr.getValueSource(indexState.exprBindings),
+                                                 // nocommit, should we be converting to long?
+                                                 expr.getDoubleValuesSource(indexState.exprBindings).toLongValuesSource(),
                                                  payloadField);
       }
 

--- a/src/java/org/apache/lucene/server/handlers/RegisterFieldsHandler.java
+++ b/src/java/org/apache/lucene/server/handlers/RegisterFieldsHandler.java
@@ -68,7 +68,7 @@ import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.search.similarities.Similarity;
@@ -382,9 +382,9 @@ public class RegisterFieldsHandler extends Handler {
     Map<String,FieldDef> allFields = new HashMap<String,FieldDef>(state.getAllFields());
     allFields.putAll(pendingFieldDefs);
 
-    ValueSource values;
+    DoubleValuesSource values;
     try {
-      values = expr.getValueSource(new FieldDefBindings(allFields));
+      values = expr.getDoubleValuesSource(new FieldDefBindings(allFields));
     } catch (RuntimeException re) {
       // Dynamic error (e.g. referred to a field that
       // doesn't exist):


### PR DESCRIPTION
Build no longer invokes lucene's ant build.

Upgrade lucene 6.3 -> 6.4, mostly just involves DoubleValuesSource.

Compile now works and tests run! But two of the tests fail.